### PR TITLE
jquery - focus caret at end of line

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -157,8 +157,10 @@ jQuery(function ($) {
 		},
 		editingMode: function (e) {
 			var $input = $(e.target).closest('li').addClass('editing').find('.edit');
-			var val = $input.val();
-			$input.val('').focus().val(val);
+			// puts caret at end of input
+			var tmpStr = $input.val();
+      			$input.val('');
+      			$input.val(tmpStr);
 		},
 		editKeyup: function (e) {
 			if (e.which === ENTER_KEY) {


### PR DESCRIPTION
Removed deprecated line that didn't move caret to end of input upon editing a todo. Added a way that works to put caret at end of input